### PR TITLE
Workaround for broken HiDPI rendering

### DIFF
--- a/src/main/kotlin/com/nasller/codeglance/panel/AbstractGlancePanel.kt
+++ b/src/main/kotlin/com/nasller/codeglance/panel/AbstractGlancePanel.kt
@@ -197,7 +197,7 @@ sealed class AbstractGlancePanel(val project: Project, textEditor: TextEditor) :
         }
         val img = getDrawImage() ?: return
         if (buf == null || buf?.width!! < width || buf?.height!! < height) {
-            buf = ImageUtil.createImage(width, height, BufferedImage.TYPE_4BYTE_ABGR)
+            buf = BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR)
         }
         val g = buf!!.createGraphics()
         g.composite = AlphaComposite.getInstance(AlphaComposite.CLEAR)

--- a/src/main/kotlin/com/nasller/codeglance/render/Minimap.kt
+++ b/src/main/kotlin/com/nasller/codeglance/render/Minimap.kt
@@ -27,7 +27,7 @@ class Minimap(private val config: Config, glancePanel: AbstractGlancePanel) {
 			if (img != null) img!!.flush()
 			// Create an image that is a bit bigger then the one we need, so we don't need to re-create it again soon.
 			// Documents can get big, so rather than relative sizes lets just add a fixed amount on.
-			img = ImageUtil.createImage(config.width, scrollState.documentHeight + (100 * config.pixelsPerLine), BufferedImage.TYPE_4BYTE_ABGR)
+			img = BufferedImage(config.width, scrollState.documentHeight + (100 * config.pixelsPerLine), BufferedImage.TYPE_4BYTE_ABGR)
 		}
 
 		val g = img!!.createGraphics()


### PR DESCRIPTION
Replace `ImageUtils.createImage` with `BufferedImage` to fix broken rendering on HiDPI displays.

<img width="935" alt="image" src="https://user-images.githubusercontent.com/3685659/162485748-988b3212-3e6e-4b76-94e3-7d6798952d6a.png">

Closes #8 
