### PR TITLE
Update `markRegex` pattern for improved matching

### DIFF
--- a/core/src/main/kotlin/com/nasller/codeglance/config/CodeGlanceConfig.kt
+++ b/core/src/main/kotlin/com/nasller/codeglance/config/CodeGlanceConfig.kt
@@ -44,7 +44,7 @@ class CodeGlanceConfig : BaseState() {
 	/** Mark */
 	var enableMarker by property(true)
 	var enableBookmarksMark by property(true)
-	var markRegex by nonNullString("(?:\\b(MARK: - )\\b|(region \\b))")
+	var markRegex by nonNullString("\\bMARK:(?: -)?(?=\\s|$)|#?region\\b")
 	var markersScaleFactor by property(3.0f)
 
 	var diffTwoSide by property(true)


### PR DESCRIPTION
This supports
- `MARK: -`
- `MARK:` (Xcode conventions)
- `region` (for languages where `#` denotes a comment)
- `#region` (for languages where `//` or `/*` is used to denote a comment)

`#region` is added as to stay editor-agnostic, as some do not recognize `//region` but do `//#region`.

Fixes: #183
Signed-off-by: Mahied Maruf <contact@mechite.com>