### PR TITLE
Wrap PSI document manager calls in runReadAction to comply with

### DIFF
--- a/src/main/kotlin/com/nasller/codeglance/panel/scroll/CustomScrollBarPopup.kt
+++ b/src/main/kotlin/com/nasller/codeglance/panel/scroll/CustomScrollBarPopup.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzerSettings
 import com.intellij.codeInsight.daemon.impl.getConfigureHighlightingLevelPopup
 import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.application.runReadAction
 import com.intellij.openapi.editor.EditorBundle
 import com.intellij.openapi.keymap.KeymapUtil
 import com.intellij.openapi.project.DumbAware
@@ -70,7 +71,7 @@ class CustomScrollBarPopup(private val glancePanel: GlancePanel) : PopupHandler(
                 }
             })
         ){}
-        glancePanel.psiDocumentManager.getPsiFile(glancePanel.editor.document)?.let {
+        runReadAction { glancePanel.psiDocumentManager.getPsiFile(glancePanel.editor.document) }?.let {
             if (DaemonCodeAnalyzer.getInstance(glancePanel.project).isHighlightingAvailable(it)) {
                 actionGroup.addSeparator()
                 actionGroup.add(createGotoGroup())

--- a/src/main/kotlin/com/nasller/codeglance/render/BaseMinimap.kt
+++ b/src/main/kotlin/com/nasller/codeglance/render/BaseMinimap.kt
@@ -51,7 +51,7 @@ abstract class BaseMinimap(protected val glancePanel: GlancePanel): InlayModel.L
 	protected val modalityState
 		get() = if (editor.editorKind != EditorKind.MAIN_EDITOR) ModalityState.any() else ModalityState.defaultModalityState()
 	protected abstract val rangeList: MutableList<Pair<Int, Range<Double>>>
-	protected val virtualFile = editor.virtualFile ?: glancePanel.psiDocumentManager.getPsiFile(glancePanel.editor.document)?.virtualFile
+	protected val virtualFile = editor.virtualFile ?: runReadAction { glancePanel.psiDocumentManager.getPsiFile(glancePanel.editor.document)?.virtualFile }
 	protected val isLogFile = virtualFile?.run { fileType::class.qualifiedName?.contains("ideolog") } == true
 	protected val lock = AtomicBoolean(false)
 	private val scaleBuffer = IntArray(4)
@@ -248,7 +248,7 @@ abstract class BaseMinimap(protected val glancePanel: GlancePanel): InlayModel.L
 		return if(markCommentMap.isNotEmpty()) {
 			val lineCount = editor.document.lineCount
 			val map = mutableMapOf<Int, MarkCommentData>()
-			val file = glancePanel.psiDocumentManager.getCachedPsiFile(editor.document)
+			val file = runReadAction { glancePanel.psiDocumentManager.getCachedPsiFile(editor.document) }
 			for (rangeMarker in markCommentMap) {
 				val attributes = rangeMarker.getTextAttributes(editor.colorsScheme)!!
 				val font = editor.colorsScheme.getFont(when (attributes.fontType) {
@@ -258,9 +258,11 @@ abstract class BaseMinimap(protected val glancePanel: GlancePanel): InlayModel.L
 					else -> EditorFontType.BOLD
 				}).deriveFont(config.markersScaleFactor * 3)
 				val startOffset = rangeMarker.startOffset
-				file?.findElementAt(startOffset)?.let { comment ->
-					val textRange = if(rangeMarker is MarkState.BookmarkHighlightDelegate)
-						comment.nextSibling?.textRange ?: comment.textRange else comment.textRange
+				runReadAction { file?.findElementAt(startOffset) }?.let { comment ->
+					val textRange = runReadAction {
+						if(rangeMarker is MarkState.BookmarkHighlightDelegate)
+							comment.nextSibling?.textRange ?: comment.textRange else comment.textRange
+					}
 					val commentText = rangeMarker.getUserData(MarkState.BOOK_MARK_DESC_KEY) ?:
 					text.substring(startOffset, rangeMarker.endOffset).trim()
 					val textFont = if (!SystemInfoRt.isMac && font.canDisplayUpTo(commentText) != -1) {


### PR DESCRIPTION
Thanks for maintaining this wonderful plugin btw, it's one of my favourites.

Another day, another EDT error (dealing with quite a few of those myself ATM...)

This change wraps a PSI document manager calls in runReadAction to comply with IntelliJ Platform 2025.2+ threading requirements.

Otherwise you'll see this error:

```
2025-12-11 04:40:16,524 [  21382] SEVERE - #c.i.u.c.ThreadingAssertions
- Read access is allowed from inside read-action only (see
Application.runReadAction()); If you access or modify model on EDT
consider wrapping your code in WriteIntentReadAction ; see
https://jb.gg/ij-platform-threading for details
Current thread: Thread[#93,AWT-EventQueue-0,6,main] 1442512862
(EventQueue.isDispatchThread()=true)
SystemEventQueueThread: (same)
com.intellij.openapi.diagnostic.RuntimeExceptionWithAttachments: Read
access is allowed from inside read-action only (see
Application.runReadAction()); If you access or modify model on EDT
consider wrapping your code in WriteIntentReadAction ; see
https://jb.gg/ij-platform-threading for details
Current thread: Thread[#93,AWT-EventQueue-0,6,main] 1442512862
(EventQueue.isDispatchThread()=true)
SystemEventQueueThread: (same)
at
com.intellij.util.concurrency.ThreadingAssertions.createThreadAccessException(ThreadingAssertions.java:257)
at
com.intellij.util.concurrency.ThreadingAssertions.softAssertReadAccess(ThreadingAssertions.java:173)
at
com.intellij.psi.impl.file.impl.FileManagerImpl.findFile(FileManagerImpl.java:517)
at
com.intellij.psi.impl.PsiDocumentManagerBase.getPsiFile(PsiDocumentManagerBase.java:130)
at
com.intellij.psi.impl.PsiDocumentManagerBase.getPsiFile(PsiDocumentManagerBase.java:112)
at
com.intellij.psi.impl.PsiDocumentManagerImpl.getPsiFile(PsiDocumentManagerImpl.java:49)
  at com.nasller.codeglance.render.BaseMinimap.<init>(BaseMinimap.kt:54)
  at com.nasller.codeglance.render.MainMinimap.<init>(MainMinimap.kt:26)
at
com.nasller.codeglance.render.BaseMinimap$Companion.getMinimap(BaseMinimap.kt:357)
  at com.nasller.codeglance.panel.GlancePanel.<init>(GlancePanel.kt:52)
at
com.nasller.codeglance.EditorPanelInjectorKt.setMyPanel(EditorPanelInjector.kt:134)
at
com.nasller.codeglance.EditorPanelInjectorKt.firstRunEditor(EditorPanelInjector.kt:88)
at
com.nasller.codeglance.EditorPanelInjectorKt.access$firstRunEditor(EditorPanelInjector.kt:1)
at
com.nasller.codeglance.EditorPanelInjector.editorCreated(EditorPanelInjector.kt:38)

```

---

Been seeing quite a few EDT errors over the place, noticed one in CodeGlancePro.

I'm also seeing another issue I think is caused by the plugin, as it doesn't seem to happen when disabled - every time I open the IDE and sometimes a project the new JetBrains Terminal shows, which I don't use, and is really annoying.

Also, I couldn't get the plugin to compile without adding this to gradle.properties:

```
org.gradle.jvmargs=-Xmx4096m
kotlin.daemon.jvmargs=-Xmx4906m
```

I also couldn't build the plugin/runIde as this error showed:

```
FAILURE: Build failed with an exception.

* Where:
Build file '/xxx/CodeGlancePro/build.gradle.kts' line: 71

* What went wrong:
/xxx/pluginCert/password.txt (No such file or directory)
```

Not sure if it breaks Gradle configuration caching, but this fixed it (also commenting it out, lol).

```kt
  // signing config only if password file (or env var) is available
  val passwordFile = File(env.getOrDefault("PRIVATE_KEY_PASSWORD", "$dir/pluginCert/password.txt"))
  if (passwordFile.exists()) {
    signing {
      certificateChainFile.set(File(env.getOrDefault("CERTIFICATE_CHAIN", "$dir/pluginCert/chain.crt")))
      privateKeyFile.set(File(env.getOrDefault("PRIVATE_KEY", "$dir/pluginCert/private.pem")))
      password.set(File(env.getOrDefault("PRIVATE_KEY_PASSWORD", "$dir/pluginCert/password.txt")).readText(Charsets.UTF_8))
    }
  }
```

Feel free to do whatever you want with this PR.